### PR TITLE
Compute SNR as a bin SNR unlike conventional  SNR definition.

### DIFF
--- a/radar_modeling/coherent_vs_noncoherent_avg.py
+++ b/radar_modeling/coherent_vs_noncoherent_avg.py
@@ -24,6 +24,7 @@ range_signal = np.exp(1j*omega_range*np.arange(num_samp_range))[:,None]
 range_signal_power = (np.linalg.norm(range_signal,2)**2/num_samp_range)
 SNR = 20
 noise_power = range_signal_power*10**(-SNR/10)
+noiseFloorPerBin = noise_power/num_samp_range
 noise_sigma = np.sqrt(noise_power)
 #noise_signal = (1/np.sqrt(num_samp_dopp))*((noise_sigma/np.sqrt(2))*np.random.randn(num_samp_range,num_samp_dopp) + 1j*(noise_sigma/np.sqrt(2))*np.random.randn(num_samp_range,num_samp_dopp))
 noise_signal = ((noise_sigma/np.sqrt(2))*np.random.randn(num_samp_range,num_samp_dopp) + 1j*(noise_sigma/np.sqrt(2))*np.random.randn(num_samp_range,num_samp_dopp))
@@ -36,10 +37,28 @@ coh_avg = np.fft.fft(signal_range_fft,axis=1)[:,0]/num_samp_dopp
 est_noise_power_range_fft = 10*np.log10((np.sum(np.abs(signal_range_fft[:,0])**2) - np.amax(np.abs(signal_range_fft[:,0]))**2))
 est_noise_power_non_coh_avg = 10*np.log10((np.sum(non_coh_avg**2) - np.amax(non_coh_avg)**2))
 est_noise_power_coh_avg = 10*np.log10((np.sum(np.abs(coh_avg)**2) - np.amax(np.abs(coh_avg))**2))
+
+estNoiseFloorPerBin_dBm_cohAvg = est_noise_power_coh_avg - 10*np.log10(num_samp_range-1);
+estNoiseFloorPerBin_dBm_noncohAvg = est_noise_power_non_coh_avg - 10*np.log10(num_samp_range-1);
+estNoiseFloorPerNin_dBm_singleChirp = est_noise_power_range_fft - 10*np.log10(num_samp_range-1);
 print('\n')
-print('\nTrue Noise Power: {0:.2f} dB \nNoise Power estimated from single chirp: {1:.2f} dB \nNoise Power non-coh Avg.: {2:.2f} dB \nNoise Power coh Avg.: {3:.2f} dB'.format(10*np.log10(noise_power), est_noise_power_range_fft,  est_noise_power_non_coh_avg, est_noise_power_coh_avg))
+# print('\nTrue Noise Power: {0:.2f} dB \nNoise Power estimated from single chirp: {1:.2f} dB \nNoise Power non-coh Avg.: {2:.2f} dB \nNoise Power coh Avg.: {3:.2f} dB'.format(10*np.log10(noise_power), est_noise_power_range_fft,  est_noise_power_non_coh_avg, est_noise_power_coh_avg))
+
+print('\nTrue Noise Power: {0:.2f} dB '.format(10*np.log10(noise_power)));
+print('Noise Power estimated from single chirp: {0:.2f} dB '.format(est_noise_power_range_fft));
+print('Noise Power non-coh Avg.: {0:.2f} dB '.format(est_noise_power_non_coh_avg))
+print('Noise Power coh Avg.: {0:.2f} dB'.format(est_noise_power_coh_avg))
+
+print('\n')
+print('True Noise Floor per bin: {0:.2f} dB'.format(10*np.log10(noiseFloorPerBin)));
+print('Noise Floor per bin est from single chirp: {0:.2f} dB'.format(estNoiseFloorPerNin_dBm_singleChirp))
+print('Noise Floor per bin est from non-coh avg: {0:.2f} dB'.format(estNoiseFloorPerBin_dBm_noncohAvg));
+print('Noise Floor per bin est from coh avg: {0:.2f} dB'.format(estNoiseFloorPerBin_dBm_cohAvg))
+
 range_grid = np.arange(-np.pi,np.pi,2*np.pi/num_samp_range)
-plt.figure(1)
+
+
+plt.figure(1,figsize=(20,10))
 plt.plot(range_grid,20*np.log10(np.fft.fftshift(np.abs(coh_avg))),alpha=0.5)
 plt.plot(range_grid,20*np.log10(np.fft.fftshift(non_coh_avg)),'k')
 plt.plot(range_grid,20*np.log10(np.fft.fftshift(np.abs(signal_range_fft[:,0]))),alpha=0.5)
@@ -47,7 +66,12 @@ plt.grid(True)
 plt.xlabel('omega range (rad/samp)')
 plt.ylabel('Power (dB)')
 plt.legend(['Coherent Avg.', 'Non-Coherent Avg.','Range FFT single chirp'])
-plt.text(-0.5, -30, 'True Noise Power: '+ str(round(10*np.log10(noise_power),3)) + ' dB')
-plt.text(-0.5, -37, 'Noise Power est from single chirp: '+ str(round(est_noise_power_range_fft,3)) + ' dB')
-plt.text(-0.5, -44, 'Noise Power est from non-coh avg: '+ str(round(est_noise_power_non_coh_avg,3)) + ' dB')
-plt.text(-0.5, -51, 'Noise Power est from coh avg: '+ str(round(est_noise_power_coh_avg,3)) + ' dB')
+plt.text(-0.5, -30, 'True Noise Power: '+ str(round(10*np.log10(noise_power),2)) + ' dB')
+plt.text(-0.5, -37, 'Noise Power est from single chirp: '+ str(round(est_noise_power_range_fft,2)) + ' dB')
+plt.text(-0.5, -44, 'Noise Power est from non-coh avg: '+ str(round(est_noise_power_non_coh_avg,2)) + ' dB')
+plt.text(-0.5, -51, 'Noise Power est from coh avg: '+ str(round(est_noise_power_coh_avg,2)) + ' dB')
+
+plt.text(-2.5, -30, 'True Noise Floor per bin: '+ str(round(10*np.log10(noiseFloorPerBin),2)) + ' dB')
+plt.text(-2.5, -37, 'Noise Floor per bin est from single chirp: '+ str(round(estNoiseFloorPerNin_dBm_singleChirp,2)) + ' dB')
+plt.text(-2.5, -44, 'Noise Floor per bin est from non-coh avg: '+ str(round(estNoiseFloorPerBin_dBm_noncohAvg,2)) + ' dB')
+plt.text(-2.5, -51, 'Noise Floor per bin est from coh avg: '+ str(round(estNoiseFloorPerBin_dBm_cohAvg,2)) + ' dB')

--- a/spectral_estimation/leastsquares_phasor_est_montecarlo.py
+++ b/spectral_estimation/leastsquares_phasor_est_montecarlo.py
@@ -37,11 +37,12 @@ freq_ind_1 = 10#np.random.randint(0,num_chirps_tx1-1);
 num_objects = 2;
 
 noise_power_db = -40; # Noise Power in dB
+noiseFloorPerBin_dB = noise_power_db - 10*np.log10(num_chirps_tx1)
 noise_variance = 10**(noise_power_db/10);
 noise_sigma = np.sqrt(noise_variance);
 
 bin_sep = np.arange(2,14,3);
-SNR = np.arange(-20,30,2);
+SNR = np.arange(15,30,1);
 num_montecarlo = 100;
 
 rmse_amp_tx1_snr_binspace = np.zeros((SNR.shape[0],num_objects,0)).astype('float32');
@@ -66,7 +67,8 @@ for freq_ind_sep in bin_sep:
     
     for snr in SNR:
         object_snr = np.array([snr,snr]);
-        signal_power = noise_variance*10**(object_snr/10);
+        # signal_power = noise_variance*10**(object_snr/10);
+        signal_power = 10**((noiseFloorPerBin_dB + object_snr)/10)
         signal_amp_real = np.sqrt(signal_power);
         random_phase = 2*np.pi*np.random.uniform(-0.5,0.5,num_objects)
         random_phasor = np.exp(1j*random_phase);
@@ -173,7 +175,7 @@ bin_sep_legend = ['bin_sep = ' + str(ele) for ele in bin_sep];
 #plt.legend(bin_sep_legend);
 #plt.grid(True);
 
-plt.figure(2,figsize=(16,9));
+plt.figure(2,figsize=(20,10));
 plt.subplot(1,2,1);
 plt.title('Angle RMSE of 1st object from 128 chirps');
 plt.plot(SNR,rmse_ang_tx1_snr_binspace[:,0,:],'-o');
@@ -210,7 +212,7 @@ plt.legend(bin_sep_legend);
 #plt.legend(bin_sep_legend);
 #plt.grid(True);
 
-plt.figure(4,figsize=(16,9));
+plt.figure(4,figsize=(20,10));
 plt.subplot(1,2,1);
 plt.title('Angle RMSE of 2nd object from 128 chirps');
 plt.plot(SNR,rmse_ang_tx1_snr_binspace[:,1,:],'-o');

--- a/spectral_estimation/spectral_estimation_test_cases.py
+++ b/spectral_estimation/spectral_estimation_test_cases.py
@@ -22,9 +22,11 @@ num_samples = 1024
 num_sources = 3
 object_snr = np.array([20,20,20])
 noise_power_db = -40 # Noise Power in dB
+noiseFloorPerBin_dB = noise_power_db - 10*np.log10(num_samples)
 noise_variance = 10**(noise_power_db/10)
 noise_sigma = np.sqrt(noise_variance)
-weights = noise_sigma*10**(object_snr/10)
+# weights = noise_sigma*10**(object_snr/10)
+weights = np.sqrt(10**((noiseFloorPerBin_dB + object_snr)/10))
 source_freq = np.random.uniform(low=-np.pi, high=np.pi, size = num_sources)
 source_signals = np.matmul(np.exp(-1j*np.outer(np.arange(num_samples),source_freq)),weights[:,None])
 wgn_noise = np.random.normal(0,noise_sigma/np.sqrt(2),source_signals.shape) + 1j*np.random.normal(0,noise_sigma/np.sqrt(2),source_signals.shape)
@@ -50,7 +52,7 @@ if 0:
     #est_freq = spec_est.esprit_toeplitz(received_signal, num_sources)
 #    est_freq = spec_est.esprit_forward(received_signal, num_sources, corr_mat_model_order)
     est_freq = spec_est.esprit_backward(received_signal, num_sources, corr_mat_model_order)
-    print('True Frequencies:', source_freq, 'Estimated Frequncies:', -est_freq)
+    print('True Frequencies:', source_freq, 'Estimated Frequncies:', est_freq)
 if 0:
 #    psd_f = spec_est.capon_forward(received_signal, corr_mat_model_order, digital_freq_grid)
     psd_b = spec_est.capon_backward(received_signal, corr_mat_model_order, digital_freq_grid)
@@ -72,11 +74,13 @@ if 1:
     plt.close('all')
     num_samples = 32
     num_sources = 2
-    object_snr = np.array([40,40])
+    object_snr = np.array([60,60])
     noise_power_db = -40 # Noise Power in dB
+    noiseFloorPerBin_dB = noise_power_db - 10*np.log10(num_samples)
     noise_variance = 10**(noise_power_db/10)
     noise_sigma = np.sqrt(noise_variance)
-    weights = noise_variance*(10**(object_snr/10))
+    # weights = noise_variance*(10**(object_snr/10))
+    weights = np.sqrt(10**((noiseFloorPerBin_dB + object_snr)/10))
     signal_phases = np.exp(1j*np.random.uniform(low=-np.pi, high = np.pi, size = num_sources))
     complex_signal_amplitudes = weights*signal_phases
     random_freq = np.random.uniform(low=-np.pi, high=np.pi, size = 1)


### PR DESCRIPTION
In this commit, I have modified the way the snr and hence signal weights
of a signal in noise are computed. The conventional definition of SNR is
the ratio of signal power to the noise power. However, when dealing with
spectrum, we typically define the bin snr to be the SNR of the object.
So in a way, it is the ratio of the signal power to the average noise
power per (FFT) bin. Taking this forward, I have mode the following
modifications to the snr based scripts.
Most importantly, for the 'radar_model_testbench.py' script, I am
computing the signal weights as follows
Previously, the Noise power was arbitrarily fixed to some value. Now, the Noise power is modelled along the lines of the receiver RF signal chain which includes the thermal noise of -174 dBm/Hz, receiver gain, noise figure, IF bandwidth.The sum of the above qunatities(in the dB scale) gives the total noise power (dBm) in the IF bandwidth. Hence the noise power bin is the ratio of the total noise power to the inherent number of signal samples(or number of FFT bins). The signal weights are then computed as 10 pow((noiseFloorPerBin_dB + SNR)/10).
I have made similar modifications to the other scripts which use snr
definitions.

Signed-off-by: Sai Gunaranjan Pelluri <saigunaranjanpelluri@gmail.com>